### PR TITLE
Publish chrome

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "name": "RoyalRefresh",
     "description": "A web extension for royalroad.com. For people who juggle multiple stories",
     "homepage_url": "https://github.com/Seismix/royalrefresh",
-    "type": "module",
+    "{{firefox}}.type": "module",
     "{{chrome}}.action": {
         "default_title": "RoyalRefresh",
         "default_popup": "ui/options.html"

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,6 @@
     "name": "RoyalRefresh",
     "description": "A web extension for royalroad.com. For people who juggle multiple stories",
     "homepage_url": "https://github.com/Seismix/royalrefresh",
-    "{{firefox}}.type": "module",
     "{{chrome}}.action": {
         "default_title": "RoyalRefresh",
         "default_popup": "ui/options.html"


### PR DESCRIPTION
During publishing to the chrome webstore a unnecessary key was found in the manifest and subsequently deleted.