### PR TITLE
feat: add automatic store publishing (#96)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,107 @@
+name: Publish
+
+on:
+    push:
+        branches: [main]
+        paths-ignore:
+            - '**.md'
+            - 'docs/**'
+            - '.github/**'
+            - '.gitignore'
+            - '.editorconfig'
+            - '.prettierrc'
+    workflow_dispatch:
+
+jobs:
+    check:
+        runs-on: ubuntu-latest
+        outputs:
+            should_publish: ${{ steps.check.outputs.should_publish }}
+            version: ${{ steps.version.outputs.version }}
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Read version from package.json
+              id: version
+              run: echo "version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
+
+            # The semver workflow already enforces a version bump on every PR to
+            # main, but guard on the tag so re-runs and non-version pushes (or a
+            # manual dispatch) never submit the same version twice.
+            - name: Skip if version already released
+              id: check
+              run: |
+                  if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+                      echo "Tag v${{ steps.version.outputs.version }} already exists - nothing to publish."
+                      echo "should_publish=false" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "should_publish=true" >> "$GITHUB_OUTPUT"
+                  fi
+
+    publish:
+        needs: check
+        if: needs.check.outputs.should_publish == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        env:
+            VERSION: ${{ needs.check.outputs.version }}
+            # Chrome only runs once a refresh token secret is present. Until then
+            # Firefox publishes on its own and the Chrome step is skipped.
+            HAS_CHROME_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN != '' }}
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: lts/*
+                  cache: 'pnpm'
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build & zip (Chrome)
+              run: pnpm zip
+
+            - name: Build & zip (Firefox + sources)
+              run: pnpm zip:firefox
+
+            - name: Submit to Firefox Add-ons
+              run: |
+                  pnpm wxt submit \
+                      --firefox-zip .output/*-firefox.zip \
+                      --firefox-sources-zip .output/*-sources.zip
+              env:
+                  FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}
+                  FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+                  FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+                  FIREFOX_CHANNEL: ${{ secrets.FIREFOX_CHANNEL }}
+
+            - name: Submit to Chrome Web Store
+              if: env.HAS_CHROME_TOKEN == 'true'
+              run: |
+                  pnpm wxt submit \
+                      --chrome-zip .output/*-chrome.zip
+              env:
+                  CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+                  CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+                  CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+                  CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+                  CHROME_PUBLISH_TARGET: ${{ secrets.CHROME_PUBLISH_TARGET }}
+                  CHROME_SKIP_SUBMIT_REVIEW: ${{ secrets.CHROME_SKIP_SUBMIT_REVIEW }}
+
+            - name: Tag and create GitHub release
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  git tag "v$VERSION"
+                  git push origin "v$VERSION"
+                  gh release create "v$VERSION" --title "v$VERSION" --generate-notes


### PR DESCRIPTION
Closes #96.

Adds `.github/workflows/publish.yaml` to automate store submission, following the [WXT publishing guide](https://wxt.dev/guide/essentials/publishing.html).

## Behaviour
- **Trigger:** push to `main` (+ manual `workflow_dispatch`).
- **Idempotent:** skips if `v<version>` is already tagged, so re-runs and non-version pushes never double-submit.
- **Steps:** install → `pnpm zip` + `pnpm zip:firefox` → `wxt submit` → tag `v<version>` + create GitHub release.
- **Firefox** publishes on its own; **Chrome** is gated on `CHROME_REFRESH_TOKEN` being set, so a missing Chrome token can't block Firefox.

## Secrets
All store credentials are configured as repo Actions secrets (Chrome + Firefox).

## Rollout
Merged into `dev` (not `main`) so it doesn't fire on a stale version. It activates on the next `dev → main` release, which will publish **v1.7.0** to both stores (stores are currently at 1.1.1, Mar 2025).