### PR TITLE
feat: user-facing error messages and loading state (#95)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "royalrefresh",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "A web extension for royalroad.com. For people who juggle multiple stories",
     "main": "background.js",
     "directories": {

--- a/src/components/extension/RecapContainer.svelte
+++ b/src/components/extension/RecapContainer.svelte
@@ -43,9 +43,14 @@
         })
     })
 
-    // Effect: Scroll into view when content becomes visible
+    // Effect: Scroll into view as soon as the recap is shown — including while
+    // it's still loading, so the reader is taken to the indicator immediately
+    // rather than waiting for the fetch to finish.
     $effect(() => {
-        if (recapState.isVisible && currentSettings?.enableJump) {
+        if (
+            (recapState.isVisible || recapState.isLoading) &&
+            currentSettings?.enableJump
+        ) {
             // Use scroll behavior, but override to instant if OS prefers reduced motion
             const behavior = prefersReducedMotion()
                 ? "instant"
@@ -87,20 +92,22 @@
 
 <div
     {id}
-    style="display: {recapState.isVisible || recapState.hasError
+    style="display: {recapState.isVisible ||
+    recapState.hasError ||
+    recapState.isLoading
         ? 'block'
         : 'none'}">
-    {#if recapState.hasError}
-        <div class="error">{recapState.error}</div>
+    {#if recapState.isLoading}
+        <!-- Reuse RoyalRoad's Bootstrap utility classes so loading/error states
+         inherit the page theme (text-muted/text-danger read on light + dark) -->
+        <div class="text-center text-muted" style="padding: 1rem;">
+            Loading…
+        </div>
+    {:else if recapState.hasError}
+        <div class="text-center text-danger" style="padding: 1rem;">
+            {recapState.error}
+        </div>
     {:else if recapState.content}
         {@html recapState.content}
     {/if}
 </div>
-
-<style>
-    .error {
-        padding: 1rem;
-        text-align: center;
-        color: #ff4444;
-    }
-</style>

--- a/src/components/extension/RecapContainer.svelte
+++ b/src/components/extension/RecapContainer.svelte
@@ -5,7 +5,7 @@
     import { ContentManager } from "~/lib/services/content-manager"
     import { getDefaults } from "~/lib/config/defaults"
     import { prefersReducedMotion } from "~/lib/utils/platform"
-    import type { ExtensionSettings } from "~/types/types"
+    import type { ContentType, ExtensionSettings } from "~/types/types"
 
     let { id = "recapContainer" }: { id?: string } = $props()
 
@@ -71,13 +71,25 @@
         ) {
             // Store the word count before processing to maintain type safety
             const newWordCount = currentSettings.wordCount
+            const settings = currentSettings
 
-            // Try to refresh from cache first
-            const result = ContentManager.refreshRecapFromCache(currentSettings)
+            // Try to refresh from cache first (fast, no network)
+            const result = ContentManager.refreshRecapFromCache(settings)
 
             if ("error" in result) {
-                // If cache refresh fails, the user can manually refresh
-                console.warn("Could not refresh from cache:", result.error)
+                // Cache expired or missing — re-fetch so the new word count
+                // still takes effect instead of leaving stale content on screen
+                recapState.setLoading()
+                ContentManager.fetchRecap(settings).then((fetchResult) => {
+                    if ("error" in fetchResult) {
+                        recapState.setError(fetchResult.error)
+                    } else {
+                        recapState.setContent(
+                            fetchResult.content,
+                            fetchResult.type as ContentType,
+                        )
+                    }
+                })
             } else {
                 recapState.setContent(result.content, result.type)
             }

--- a/src/components/extension/ToggleButton.svelte
+++ b/src/components/extension/ToggleButton.svelte
@@ -19,6 +19,11 @@
             buttonElement.blur()
         }
 
+        // Ignore clicks while a fetch is already in flight
+        if (recapState.isLoading) {
+            return
+        }
+
         // If we're currently visible, just toggle to hide
         if (recapState.visibility === "visible") {
             recapState.hide()
@@ -32,6 +37,7 @@
         }
 
         // If we don't have content, fetch it first then show
+        recapState.setLoading()
         const settings = await getSettings()
         const result =
             type === "recap"
@@ -55,7 +61,12 @@
     class="btn btn-primary btn-circle"
     onclick={handleToggle}
     id={buttonId}
+    disabled={recapState.isLoading}
     style="outline: none !important;">
     <i class="fa fa-{iconName}" style="margin-right: 0.15em;"></i>
-    <span>{recapState.toggleText}</span>{buttonText}
+    {#if recapState.isLoading}
+        <span>Loading…</span>
+    {:else}
+        <span>{recapState.toggleText}</span>{buttonText}
+    {/if}
 </button>

--- a/src/lib/services/content-manager.ts
+++ b/src/lib/services/content-manager.ts
@@ -43,9 +43,7 @@ export class ContentManager {
         // 3. Fetch from network
         const fetchResult = await fetchHtml(prevChapterUrl)
         if ("error" in fetchResult) {
-            return {
-                error: `Failed to fetch previous chapter: ${fetchResult.error}`,
-            }
+            return { error: fetchResult.error }
         }
 
         // 4. Cache the raw HTML
@@ -81,9 +79,7 @@ export class ContentManager {
         // 2. Fetch from network (no caching for blurb)
         const fetchResult = await fetchHtml(overviewUrl)
         if ("error" in fetchResult) {
-            return {
-                error: `Failed to fetch story overview: ${fetchResult.error}`,
-            }
+            return { error: fetchResult.error }
         }
 
         // 3. Process the content

--- a/src/lib/services/content-processor.ts
+++ b/src/lib/services/content-processor.ts
@@ -1,6 +1,11 @@
 import type { ExtensionSettings } from "~/types/types"
 import { HtmlSanitizer } from "./"
 
+/** Appended to selector-failure messages — these usually mean RoyalRoad
+ * changed its page layout, which the user can flag via the Report button. */
+const LAYOUT_HINT =
+    "RoyalRoad's layout may have changed — please report this with the Report button."
+
 /**
  * Content Processing Service - Pure functions for processing HTML content
  * No side effects, returns result objects with processed content or errors
@@ -52,14 +57,18 @@ export class ContentProcessor {
             tempDiv.appendChild(fragment)
 
             // Sanitize the HTML content before returning
-            const sanitizedContent = HtmlSanitizer.sanitize(tempDiv.innerHTML)
+            const rawHtml = tempDiv.innerHTML
+            const sanitizedContent = HtmlSanitizer.sanitize(rawHtml)
+
+            // Guard against sanitization silently swallowing all content
+            if (rawHtml.trim() && !sanitizedContent.trim()) {
+                return { error: "Could not safely display the recap content." }
+            }
+
             return { content: sanitizedContent }
-        } catch (error) {
+        } catch {
             return {
-                error:
-                    error instanceof Error
-                        ? `Failed to process recap: ${error.message}`
-                        : "Failed to process recap content",
+                error: "Could not build the recap. RoyalRoad's layout may have changed — please report this with the Report button.",
             }
         }
     }
@@ -102,14 +111,18 @@ export class ContentProcessor {
             tempDiv.appendChild(fragment)
 
             // Sanitize the HTML content before returning
-            const sanitizedContent = HtmlSanitizer.sanitize(tempDiv.innerHTML)
+            const rawHtml = tempDiv.innerHTML
+            const sanitizedContent = HtmlSanitizer.sanitize(rawHtml)
+
+            // Guard against sanitization silently swallowing all content
+            if (rawHtml.trim() && !sanitizedContent.trim()) {
+                return { error: "Could not safely display the blurb content." }
+            }
+
             return { content: sanitizedContent }
-        } catch (error) {
+        } catch {
             return {
-                error:
-                    error instanceof Error
-                        ? `Failed to process blurb: ${error.message}`
-                        : "Failed to process blurb content",
+                error: "Could not build the blurb. RoyalRoad's layout may have changed — please report this with the Report button.",
             }
         }
     }
@@ -125,7 +138,9 @@ export class ContentProcessor {
         )
 
         if (!fictionTitleElement || !fictionTitleElement.textContent) {
-            return { error: "Could not find fiction title on current page" }
+            return {
+                error: `Could not find the story title on this page. ${LAYOUT_HINT}`,
+            }
         }
 
         return { data: fictionTitleElement.textContent.trim() }
@@ -141,7 +156,9 @@ export class ContentProcessor {
         const chapterTitleElement = doc.querySelector(settings.chapterTitle)
 
         if (!chapterTitleElement || !chapterTitleElement.textContent) {
-            return { error: "Could not find chapter title in fetched content" }
+            return {
+                error: `Could not find the previous chapter's title. ${LAYOUT_HINT}`,
+            }
         }
 
         return { data: chapterTitleElement.textContent.trim() }
@@ -169,11 +186,13 @@ export class ContentProcessor {
         const blurbElement = overviewDoc.querySelector(settings.blurb)
 
         if (!blurbElement || !(blurbElement instanceof HTMLElement)) {
-            return { error: "Could not find story blurb in overview page" }
+            return {
+                error: `Could not find the story blurb on the overview page. ${LAYOUT_HINT}`,
+            }
         }
 
         if (!blurbElement.textContent || !blurbElement.textContent.trim()) {
-            return { error: "Story blurb appears to be empty" }
+            return { error: "The story blurb appears to be empty." }
         }
 
         fragment.appendChild(blurbElement.cloneNode(true) as HTMLElement)
@@ -191,16 +210,20 @@ export class ContentProcessor {
         const chapterElement = chapterDoc.querySelector(settings.chapterContent)
 
         if (!chapterElement) {
-            return { error: "Could not find chapter content in fetched page" }
+            return {
+                error: `Could not find the previous chapter's content. ${LAYOUT_HINT}`,
+            }
         }
 
         if (!chapterElement.textContent?.trim()) {
-            return { error: "Chapter content appears to be empty" }
+            return { error: "The previous chapter appears to be empty." }
         }
 
         const paragraphs = chapterElement.querySelectorAll("p")
         if (paragraphs.length === 0) {
-            return { error: "No paragraphs found in chapter content" }
+            return {
+                error: `Could not read any text from the previous chapter. ${LAYOUT_HINT}`,
+            }
         }
 
         return this.selectParagraphsByWordCount(paragraphs, settings.wordCount)

--- a/src/lib/services/http-client.ts
+++ b/src/lib/services/http-client.ts
@@ -1,15 +1,40 @@
+/** Abort a request that takes longer than this, so a hung connection
+ * surfaces a real error instead of leaving the recap stuck loading forever. */
+const REQUEST_TIMEOUT_MS = 15000
+
+/**
+ * Maps an HTTP status to a reader-friendly message.
+ */
+function describeHttpError(status: number) {
+    if (status === 404) {
+        return "That chapter could not be found on RoyalRoad (404)."
+    }
+    if (status === 429) {
+        return "RoyalRoad is rate-limiting requests. Please wait a moment and try again."
+    }
+    if (status >= 500) {
+        return "RoyalRoad is having problems right now. Please try again later."
+    }
+    return "RoyalRoad could not load that page. Please try again."
+}
+
 /**
  * Fetches HTML content from a URL
  * @param url - The URL to fetch content from
  * @returns Promise resolving to either success data or error message
  */
-export async function fetchHtml(url: string | URL | Request) {
+export async function fetchHtml(
+    url: string | URL | Request,
+): Promise<{ data: string } | { error: string }> {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
     try {
-        const response = await fetch(url)
+        const response = await fetch(url, { signal: controller.signal })
 
         if (!response.ok) {
             return {
-                error: `Failed to fetch content: ${response.status} ${response.statusText}`,
+                error: describeHttpError(response.status),
             }
         }
 
@@ -17,20 +42,28 @@ export async function fetchHtml(url: string | URL | Request) {
 
         if (!html || html.trim().length === 0) {
             return {
-                error: "Received empty response from server",
+                error: "RoyalRoad returned an empty page. Please try again.",
             }
         }
 
         return { data: html }
     } catch (error) {
+        // Timeout: AbortController fired before the request completed
+        if (error instanceof Error && error.name === "AbortError") {
+            return {
+                error: "Request timed out — RoyalRoad took too long to respond. Please try again.",
+            }
+        }
         // Network errors, CORS issues, etc.
         if (error instanceof Error) {
             return {
-                error: `Network error: ${error.message}`,
+                error: "Could not reach RoyalRoad. Please check your connection and try again.",
             }
         }
         return {
-            error: "Unknown error occurred while fetching content",
+            error: "Something went wrong while loading the content. Please try again.",
         }
+    } finally {
+        clearTimeout(timeoutId)
     }
 }

--- a/src/lib/state/recap-state.svelte.ts
+++ b/src/lib/state/recap-state.svelte.ts
@@ -1,6 +1,6 @@
 import type { ContentType } from "~/types/types"
 
-export type RecapState = "hidden" | "visible" | "error"
+export type RecapState = "hidden" | "visible" | "error" | "loading"
 
 /**
  * Reactive recap state using Svelte 5 runes - Pure UI state management
@@ -19,6 +19,15 @@ class RecapStateManager {
         this.content = content
         this.type = type
         this.visibility = "visible"
+        this.error = null
+    }
+
+    /**
+     * Marks content as loading. Keeps any existing content (e.g. during a
+     * word-count refresh) but clears errors and shows the loading indicator.
+     */
+    setLoading() {
+        this.visibility = "loading"
         this.error = null
     }
 
@@ -52,6 +61,7 @@ class RecapStateManager {
     // Computed properties using $derived
     toggleText = $derived(this.visibility === "visible" ? "Hide " : "Show ")
     isVisible = $derived(this.visibility === "visible")
+    isLoading = $derived(this.visibility === "loading")
     hasError = $derived(this.visibility === "error" && this.error !== null)
 }
 

--- a/src/lib/utils/dom-utils.ts
+++ b/src/lib/utils/dom-utils.ts
@@ -108,21 +108,24 @@ export function findFictionOverviewUrl(
 ): { data: string } | { error: string } {
     const fictionTitleElement = document.querySelector(settings.fictionTitle)
 
+    const layoutHint =
+        "RoyalRoad's layout may have changed — please report this with the Report button."
+
     if (!fictionTitleElement) {
         return {
-            error: "Could not find fiction title on current page.",
+            error: `Could not find the story title on this page. ${layoutHint}`,
         }
     }
 
     if (!(fictionTitleElement.parentElement instanceof HTMLAnchorElement)) {
         return {
-            error: "Fiction title found but is not linked to overview page.",
+            error: `Could not find a link to the story's overview page. ${layoutHint}`,
         }
     }
 
     if (!fictionTitleElement.parentElement.href) {
         return {
-            error: "Fiction title link found but has no URL.",
+            error: `The story's overview link is missing its address. ${layoutHint}`,
         }
     }
 


### PR DESCRIPTION
Closes #95.

Implements user-facing error handling and a loading state for recap/blurb fetches. Split into three reviewable commits:

1. **Loading state** — centered "Loading…" indicator while a fetch is in flight, scrolls to it as soon as it appears, and the toggle is disabled to ignore repeat clicks during a fetch. Loading/error states reuse RoyalRoad's Bootstrap utility classes (`text-muted`/`text-danger`) so they inherit the page theme on light and dark backgrounds.
2. **Resilient fetching** — 15s timeout so a hung connection surfaces a real error instead of an indefinite spinner, friendly HTTP/network messages, and a re-fetch when a word-count change misses the cache (previously left stale content silently).
3. **Clearer messages + sanitizer guard** — selector-failure messages reworded in plain language pointing to the Report button, plus a guard against the sanitizer silently swallowing all content.

## Testing
Verified in-browser: loading indicator, network-unreachable, happy path, re-entrancy guard, word-count refresh (cache hit + miss), blurb path, scroll-on-load.

Not reachable on real RoyalRoad without faking the response: HTTP status messages (404/429/5xx/empty/timeout) and the sanitizer-strips-everything path. These are simple branches; automated coverage for them is deferred (Phase 5).